### PR TITLE
refactor: produce internal txs to kafka before import

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -270,6 +270,17 @@ defmodule Indexer.Fetcher.InternalTransaction do
     internal_transactions_and_empty_block_numbers =
       internal_transactions_params_without_failed_creations ++ empty_block_numbers
 
+    #produce internal txs to kafka before import
+    trace_first_block = EthereumJSONRPC.first_block_to_fetch(:trace_first_block)
+    if length(internal_transactions_params_without_failed_creations) > 0
+       && Enum.at(internal_transactions_params_without_failed_creations, 0).block_number >= trace_first_block do
+      json_internal_txs = Poison.encode!(internal_transactions_params_without_failed_creations)
+      topic = "internal-txs"
+      Task.start(fn ->
+        Kaffe.Producer.produce_sync(topic, "#{Enum.at(internal_transactions_params_without_failed_creations, 0).block_number}", json_internal_txs)
+      end)
+    end
+
     imports =
       Chain.import(%{
         addresses: %{params: addresses_params},
@@ -279,17 +290,6 @@ defmodule Indexer.Fetcher.InternalTransaction do
 
     case imports do
       {:ok, imported} ->
-        #produce internal txs to kafka after successfully imported
-        trace_first_block = EthereumJSONRPC.first_block_to_fetch(:trace_first_block)
-        if length(internal_transactions_params_without_failed_creations) > 0
-           && Enum.at(internal_transactions_params_without_failed_creations, 0).block_number >= trace_first_block do
-          json_internal_txs = Poison.encode!(internal_transactions_params_without_failed_creations)
-          topic = "internal-txs"
-          Task.start(fn ->
-            Kaffe.Producer.produce_sync(topic, "#{Enum.at(internal_transactions_params_without_failed_creations, 0).block_number}", json_internal_txs)
-          end)
-        end
-
         Accounts.drop(imported[:addreses])
         Blocks.drop_nonconsensus(imported[:remove_consensus_of_missing_transactions_blocks])
 


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*

## Changelog

### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
