### PR TITLE
chore: retry fetch internal txs when reorgs occur

### DIFF
--- a/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
+++ b/apps/indexer/lib/indexer/fetcher/internal_transaction.ex
@@ -134,13 +134,14 @@ defmodule Indexer.Fetcher.InternalTransaction do
         Logger.error(fn -> ["failed to fetch internal transactions for blocks: ", inspect(reason)] end,
           error_count: filtered_unique_numbers_count
         )
-        try do
-          tx_hash = Enum.at(reason, 0)[:data][:transaction_hash]
-          Chain.update_txs_has_error_in_internal_txs(tx_hash)
-        rescue
-          _ ->
-            :ok
-        end
+        #try do
+        #  tx_hash = Enum.at(reason, 0)[:data][:transaction_hash]
+        #  Chain.update_txs_has_error_in_internal_txs(tx_hash)
+        #rescue
+        #  _ ->
+        #    :ok
+        #end
+
 
         # re-queue the de-duped entries
         {:retry, filtered_unique_numbers}
@@ -185,8 +186,8 @@ defmodule Indexer.Fetcher.InternalTransaction do
     cond do
       blank_input?(param[:input]) == true ->
         false
-      !is_nil(param[:has_error_in_internal_txs]) ->
-        false
+      #!is_nil(param[:has_error_in_internal_txs]) ->
+      #  false
       true ->
         true
     end


### PR DESCRIPTION
*[GitHub keywords to close any associated issues](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/)*

## Motivation

*Why we should merge these changes.  If using GitHub keywords to close [issues](https://github.com/poanetwork/blockscout/issues), this is optional as the motivation can be read on the issue page.*

## Changelog

### Enhancements
*Things you added that don't break anything.  Regression tests for Bug Fixes count as Enhancements.*

### Bug Fixes
*Things you changed that fix bugs.  If a fixes a bug, but in so doing adds a new requirement, removes code, or requires a database reset and reindex, the breaking part of the change should be added to Incompatible Changes below also.*

### Incompatible Changes
*Things you broke while doing Enhancements and Bug Fixes.  Breaking changes include (1) adding new requirements and (2) removing code.  Renaming counts as (2) because a rename is a removal followed by an add.*

## Upgrading

*If you have any Incompatible Changes in the above Changelog, outline how users of prior versions can upgrade once this PR lands or when reviewers are testing locally.  A common upgrading step is "Database reset and re-index required".*

## Checklist for your Pull Request (PR)

  - [x] I added an entry to `CHANGELOG.md` with this PR
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from silently reappearing again.
  - [x] I checked whether I should update the docs and did so by submitting a PR to https://github.com/blockscout/docs
  - [x] If I added/changed/removed ENV var, I submitted a PR to https://github.com/blockscout/docs to update the list of env vars at https://github.com/blockscout/docs/blob/master/for-developers/information-and-settings/env-variables.md and I updated the version to `master` in the Version column. Changes will be reflected in this table: https://docs.blockscout.com/for-developers/information-and-settings/env-variables. 
  - [x] If I add new indices into DB, I checked, that they are not redundant with PGHero or other tools
